### PR TITLE
Ensures that the migrations only run when required.

### DIFF
--- a/src/tests/utils/setupService.ts
+++ b/src/tests/utils/setupService.ts
@@ -1,17 +1,16 @@
+import { once } from 'lodash';
 import 'mocha'; // tslint:disable-line
 import Service from '../../serviceFactory/Service';
 
-const migrateService = async (service: Service) => {
-  await service.rollback();
-  await service.migrate();
-};
-
 export default <ConcreteService extends Service>(service: ConcreteService) => {
-  const migrations = migrateService(service);
+  const migrateService = once(async () => {
+    await service.rollback();
+    await service.migrate();
+  });
 
   return (): ConcreteService => {
     before(async () => {
-      await migrations;
+      await migrateService();
     });
 
     beforeEach(async () => {


### PR DESCRIPTION
Previously the migrations would run straight away, so if setupService was used twice within a test suite, it would try to migrate the same database twice causing the "before all" hook to fail because the "Migration table is already locked".